### PR TITLE
Allow secrets to contain newlines & special characters

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -79,15 +79,24 @@ heading() {
 APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); cd ..; pwd)
 BIN_DIR="$APP_DIR/vendor/bin"
 
-decrypt_output=$(echo $EJSON_PRIVATE_KEY | $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1)
+exports=$(echo $EJSON_PRIVATE_KEY | \
+  $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1 | \
+  $BIN_DIR/jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' | \
+  grep -v '^export _public_key=' | \
+  while IFS=$'\n' read -r line
+  do
+    echo "Line: $line" >> /tmp/export.log
+    echo $line
+  done)
+
 if [ $? -eq 0 ]; then
-  exports=$(echo $decrypt_output | $BIN_DIR/jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" | grep -v '^_public_key=')
-  for env_var in $exports; do
-    export $env_var
-  done
+  eval "$exports"
 else
-  heading $decrypt_output
+  heading "Decryption failed"
 fi
+
+echo "Exp: $exports" >> /tmp/export.log
+echo "FOO: $foo" >> /tmp/export.log
 EOP
 chmod +x $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 

--- a/bin/compile
+++ b/bin/compile
@@ -94,6 +94,8 @@ else
   heading "Decryption failed"
 
   # Don't exit 1 here to allow heroku ps:exec to work
+  # App environment variables are only available when booting the app, when ps:exec runs they are not available
+  # here which would cause this to fail
   export EJSON_DECRYPT_FAILED=true
 fi
 EOP

--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -o pipefail
 
 heading() {
   echo "----->" $@;
@@ -81,11 +81,10 @@ BIN_DIR="$APP_DIR/vendor/bin"
 
 exports=$(echo $EJSON_PRIVATE_KEY | \
   $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1 | \
-  $BIN_DIR/jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' | \
+  $BIN_DIR/jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' 2>&1 | \
   grep -v '^export _public_key=' | \
   while IFS=$'\n' read -r line
   do
-    echo "Line: $line" >> /tmp/export.log
     echo $line
   done)
 
@@ -93,14 +92,19 @@ if [ $? -eq 0 ]; then
   eval "$exports"
 else
   heading "Decryption failed"
-fi
 
-echo "Exp: $exports" >> /tmp/export.log
-echo "FOO: $foo" >> /tmp/export.log
+  # Don't exit 1 here to allow heroku ps:exec to work
+  export EJSON_DECRYPT_FAILED=true
+fi
 EOP
 chmod +x $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 
 export EJSON_PRIVATE_KEY=$(cat "$ENV_DIR/EJSON_PRIVATE_KEY")
 
 heading "Sourcing environment variables on compile"
+export HEROKU_COMPILE=true
 source $BUILD_DIR/.profile.d/export_ejson_secrets.sh
+
+if [[ "${EJSON_DECRYPT_FAILED}" == "true" ]]; then
+  exit 1
+fi

--- a/bin/compile
+++ b/bin/compile
@@ -102,7 +102,6 @@ chmod +x $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 export EJSON_PRIVATE_KEY=$(cat "$ENV_DIR/EJSON_PRIVATE_KEY")
 
 heading "Sourcing environment variables on compile"
-export HEROKU_COMPILE=true
 source $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 
 if [[ "${EJSON_DECRYPT_FAILED}" == "true" ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -95,7 +95,7 @@ else
 
   # Don't exit 1 here to allow heroku ps:exec to work
   # App environment variables are only available when booting the app, when ps:exec runs they are not available
-  # here which would cause this to fail
+  # here which would cause ps:exec to fail.
   export EJSON_DECRYPT_FAILED=true
 fi
 EOP

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -37,51 +37,48 @@ export_env_dir() {
 }
 
 capture_profile_d_export_script() {
-  capture "source $TMPDIR/build/.profile.d/export_ejson_secrets.sh"
+  source $TMPDIR/build/.profile.d/export_ejson_secrets.sh
 }
 
 test_simple() {
-  (
     compile_with_fixture simple
     assertCapturedSuccess
 
     capture_profile_d_export_script
     assertCapturedSuccess
-    assertEquals "bar" "$foo"
+    echo $foo
+    assertEquals "Bar's Baz
+
+Hello" "$foo"
     assertEquals "" "$_public_key"
-  )
 }
 
 test_missing_private_key() {
-  (
-    compile_with_fixture missing_private_key
-    assertCapturedError
-    assertCaptured 'EJSON_PRIVATE_KEY is undefined; make sure EJSON_PRIVATE_KEY and EJSON_FILE are set'
-  )
+  compile_with_fixture missing_private_key
+  assertCapturedError
+  assertCaptured 'EJSON_PRIVATE_KEY is undefined; make sure EJSON_PRIVATE_KEY and EJSON_FILE are set'
 }
 
-test_missing_ejson_file() {
-  (
-    compile_with_fixture missing_ejson_file
-    assertCapturedError
-    assertCaptured 'EJSON_FILE is undefined; make sure EJSON_PRIVATE_KEY and EJSON_FILE are set'
-  )
-}
+# test_missing_ejson_file() {
+#   (
+#     compile_with_fixture missing_ejson_file
+#     assertCapturedError
+#     assertCaptured 'EJSON_FILE is undefined; make sure EJSON_PRIVATE_KEY and EJSON_FILE are set'
+#   )
+# }
 
-test_ejson_file_not_found_in_build_dir() {
-  (
-    compile_with_fixture missing_ejson_file_in_build
-    capture_profile_d_export_script
-    assertCapturedError
-    assertCaptured "EJSON_FILE could not be found at config.ejson"
-  )
-}
+# test_ejson_file_not_found_in_build_dir() {
+#   (
+#     compile_with_fixture missing_ejson_file_in_build
+#     capture_profile_d_export_script
+#     assertCapturedError
+#     assertCaptured "EJSON_FILE could not be found at config.ejson"
+#   )
+# }
 
 test_bad_keypair() {
-  (
-    compile_with_fixture bad_keypair
-    capture_profile_d_export_script
-    assertCapturedError
-    assertCaptured "Decryption failed: couldn't decrypt message"
-  )
+  compile_with_fixture bad_keypair
+  capture_profile_d_export_script
+  assertCapturedError
+  assertCaptured "Decryption failed: couldn't decrypt message"
 }

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -8,6 +8,8 @@ mkdir -p $CACHETMP
 
 beforeSetUp() {
   TMPDIR=$(mktemp -d)
+  unset foo
+  unset _public_key
 }
 
 beforeTearDown() {
@@ -37,20 +39,19 @@ export_env_dir() {
 }
 
 capture_profile_d_export_script() {
-  source $TMPDIR/build/.profile.d/export_ejson_secrets.sh
+  capture "source $TMPDIR/build/.profile.d/export_ejson_secrets.sh"
 }
 
 test_simple() {
-    compile_with_fixture simple
-    assertCapturedSuccess
+  compile_with_fixture simple
+  assertCapturedSuccess
 
-    capture_profile_d_export_script
-    assertCapturedSuccess
-    echo $foo
-    assertEquals "Bar's Baz
+  capture_profile_d_export_script
+  assertCapturedSuccess
+  assertEquals "Bar's Baz
 
 Hello" "$foo"
-    assertEquals "" "$_public_key"
+  assertEquals "" "$_public_key"
 }
 
 test_missing_private_key() {
@@ -59,26 +60,20 @@ test_missing_private_key() {
   assertCaptured 'EJSON_PRIVATE_KEY is undefined; make sure EJSON_PRIVATE_KEY and EJSON_FILE are set'
 }
 
-# test_missing_ejson_file() {
-#   (
-#     compile_with_fixture missing_ejson_file
-#     assertCapturedError
-#     assertCaptured 'EJSON_FILE is undefined; make sure EJSON_PRIVATE_KEY and EJSON_FILE are set'
-#   )
-# }
+test_missing_ejson_file() {
+  compile_with_fixture missing_ejson_file
+  assertCapturedError
+  assertCaptured 'EJSON_FILE is undefined; make sure EJSON_PRIVATE_KEY and EJSON_FILE are set'
+}
 
-# test_ejson_file_not_found_in_build_dir() {
-#   (
-#     compile_with_fixture missing_ejson_file_in_build
-#     capture_profile_d_export_script
-#     assertCapturedError
-#     assertCaptured "EJSON_FILE could not be found at config.ejson"
-#   )
-# }
+test_ejson_file_not_found_in_build_dir() {
+  compile_with_fixture missing_ejson_file_in_build
+  assertCapturedError
+  assertCaptured "EJSON_FILE could not be found at config.ejson"
+}
 
 test_bad_keypair() {
   compile_with_fixture bad_keypair
-  capture_profile_d_export_script
   assertCapturedError
-  assertCaptured "Decryption failed: couldn't decrypt message"
+  assertCaptured "Decryption failed"
 }

--- a/test/fixtures/simple/build/config.ejson
+++ b/test/fixtures/simple/build/config.ejson
@@ -1,3 +1,4 @@
 {
   "_public_key": "eacea45fab0fc091e7b8826030edd06fdd0a961d69235a481d98a73128cb955f",
-  "foo": "EJ[1:k0DVbsrtU+JDXGgLqGt8waFlcTLTcHUTgSejEDaq0kY=:znHf4tfNw23xJbtyCbn+XW2ZjRVQhpt6:wB0slE/sFN/uukgmi9nxEjpjrDwritDAZDrEAJcT+/c=]"}
+  "foo": "EJ[1:k0DVbsrtU+JDXGgLqGt8waFlcTLTcHUTgSejEDaq0kY=:znHf4tfNw23xJbtyCbn+XW2ZjRVQhpt6:wB0slE/sFN/uukgmi9nxEjpjrDwritDAZDrEAJcT+/c=]"
+}

--- a/test/fixtures/simple/build/config.ejson
+++ b/test/fixtures/simple/build/config.ejson
@@ -1,3 +1,3 @@
 {
   "_public_key": "eacea45fab0fc091e7b8826030edd06fdd0a961d69235a481d98a73128cb955f",
-  "foo": "EJ[1:7hnZohgj3f2IAee5McL0IkexsO++xuVHKj9A0k9G7DY=:4S7TTDCisAp5Wx8fsGWGvyI4EqycL8lq:1Oa/OPwzk3G4KfOyeimZh+rNLg==]"}
+  "foo": "EJ[1:k0DVbsrtU+JDXGgLqGt8waFlcTLTcHUTgSejEDaq0kY=:znHf4tfNw23xJbtyCbn+XW2ZjRVQhpt6:wB0slE/sFN/uukgmi9nxEjpjrDwritDAZDrEAJcT+/c=]"}


### PR DESCRIPTION
- Uses `|tojson` in jq to encode the string as it would be in JSON.
- One pipe had to be used. For some reason, assigning the value of the ejson output to a variable and then `echo $decryption_output | ` to the rest of the chain causes the newlines to be evaluated and `jq` to complain about newlines not being encoded properly. The downside here is we don't see the reason for a decryption failure
- Removes subshells from the tests since it causes the test suite as a whole not to fail on error