### PR TITLE
Define export_ejson_secrets function in profile.d script to be called from application's .profile script

### DIFF
--- a/.profile.d/ejson_secrets.sh
+++ b/.profile.d/ejson_secrets.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -o pipefail
+
+heading() {
+  echo "----->" $@;
+}
+
+APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); cd ..; pwd)
+BIN_DIR="$APP_DIR/vendor/bin"
+
+decrypt_ejson_file() {
+  echo $EJSON_PRIVATE_KEY | \
+    $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1
+}
+
+json_to_export_lines() {
+  $BIN_DIR/jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' 2>&1 | \
+    grep -v '^export _public_key='
+}
+
+ejson_exports() {
+  decrypt_ejson_file | \
+    json_to_export_lines | \
+    while IFS=$'\n' read -r line
+    do
+      echo $line
+    done
+}
+
+export_ejson_secrets() {
+  exports=$(ejson_exports)
+  return_status=$?
+
+  if [ $return_status -eq 0 ]; then
+    eval "$exports"
+  else
+    # re-execute decryption to get failure message then display
+    decryption_output=$(decrypt_ejson_file)
+    # make sure it's still not successful this time
+    if [ $? -ne 0 ]; then
+      heading "$decryption_output"
+    fi
+  fi
+
+  return $return_status
+}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Add this Heroku buildpack:
 ❯ heroku buildpacks:set https://github.com/envato/heroku-buildpack-ejson.git
 ```
 
+Add this line to your application's `.profile` script:
+
+```
+export_ejson_secrets
+```
+
 On application start, it will use those 2 environment variables to decrypt the ejson file and export the secrets
 as environment variables.
 

--- a/bin/compile
+++ b/bin/compile
@@ -79,25 +79,43 @@ heading() {
 APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); cd ..; pwd)
 BIN_DIR="$APP_DIR/vendor/bin"
 
-exports=$(echo $EJSON_PRIVATE_KEY | \
-  $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1 | \
+decrypt_ejson_file() {
+  echo $EJSON_PRIVATE_KEY | \
+    $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1
+}
+
+json_to_export_lines() {
   $BIN_DIR/jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' 2>&1 | \
-  grep -v '^export _public_key=' | \
-  while IFS=$'\n' read -r line
-  do
-    echo $line
-  done)
+    grep -v '^export _public_key='
+}
 
-if [ $? -eq 0 ]; then
-  eval "$exports"
-else
-  heading "Decryption failed"
+ejson_exports() {
+  decrypt_ejson_file | \
+    json_to_export_lines | \
+    while IFS=$'\n' read -r line
+    do
+      echo $line
+    done
+}
 
-  # Don't exit 1 here to allow heroku ps:exec to work
-  # App environment variables are only available when booting the app, when ps:exec runs they are not available
-  # here which would cause ps:exec to fail.
-  export EJSON_DECRYPT_FAILED=true
-fi
+export_ejson_secrets() {
+  exports=$(ejson_exports)
+  return_status=$?
+
+  if [ $return_status -eq 0 ]; then
+    eval "$exports"
+  else
+    # re-execute decryption to get failure message then display
+    decryption_output=$(decrypt_ejson_file)
+    # make sure it's still not successful this time
+    if [ $? -ne 0 ]; then
+      heading "$decryption_output"
+    fi
+  fi
+
+  return $return_status
+}
+
 EOP
 chmod +x $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 
@@ -106,6 +124,7 @@ export EJSON_PRIVATE_KEY=$(cat "$ENV_DIR/EJSON_PRIVATE_KEY")
 heading "Sourcing environment variables on compile"
 source $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 
-if [[ "${EJSON_DECRYPT_FAILED}" == "true" ]]; then
+export_ejson_secrets
+if [ $? -ne 0 ]; then
   exit 1
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -69,13 +69,13 @@ fi
 mkdir -p $BUILD_DIR/.profile.d
 
 BUILDPACK_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); cd ..; pwd)
-cp $BUILDPACK_DIR/.profile.d/ejson_secrets.sh $BUILD_DIR/.profile.d/export_ejson_secrets.sh
-chmod +x $BUILD_DIR/.profile.d/export_ejson_secrets.sh
+cp $BUILDPACK_DIR/.profile.d/ejson_secrets.sh $BUILD_DIR/.profile.d/ejson_secrets.sh
+chmod +x $BUILD_DIR/.profile.d/ejson_secrets.sh
 
 export EJSON_PRIVATE_KEY=$(cat "$ENV_DIR/EJSON_PRIVATE_KEY")
 
 heading "Sourcing environment variables on compile"
-source $BUILD_DIR/.profile.d/export_ejson_secrets.sh
+source $BUILD_DIR/.profile.d/ejson_secrets.sh
 
 export_ejson_secrets
 if [[ $? -ne 0 ]]; then

--- a/bin/compile
+++ b/bin/compile
@@ -125,6 +125,6 @@ heading "Sourcing environment variables on compile"
 source $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 
 export_ejson_secrets
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]; then
   exit 1
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -67,56 +67,9 @@ if [ ! -f "$BUILD_DIR/$EJSON_FILE" ]; then
 fi
 
 mkdir -p $BUILD_DIR/.profile.d
-cat > $BUILD_DIR/.profile.d/export_ejson_secrets.sh <<"EOP"
-#!/bin/bash
 
-set -o pipefail
-
-heading() {
-  echo "----->" $@;
-}
-
-APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); cd ..; pwd)
-BIN_DIR="$APP_DIR/vendor/bin"
-
-decrypt_ejson_file() {
-  echo $EJSON_PRIVATE_KEY | \
-    $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1
-}
-
-json_to_export_lines() {
-  $BIN_DIR/jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' 2>&1 | \
-    grep -v '^export _public_key='
-}
-
-ejson_exports() {
-  decrypt_ejson_file | \
-    json_to_export_lines | \
-    while IFS=$'\n' read -r line
-    do
-      echo $line
-    done
-}
-
-export_ejson_secrets() {
-  exports=$(ejson_exports)
-  return_status=$?
-
-  if [ $return_status -eq 0 ]; then
-    eval "$exports"
-  else
-    # re-execute decryption to get failure message then display
-    decryption_output=$(decrypt_ejson_file)
-    # make sure it's still not successful this time
-    if [ $? -ne 0 ]; then
-      heading "$decryption_output"
-    fi
-  fi
-
-  return $return_status
-}
-
-EOP
+BUILDPACK_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); cd ..; pwd)
+cp $BUILDPACK_DIR/.profile.d/ejson_secrets.sh $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 chmod +x $BUILD_DIR/.profile.d/export_ejson_secrets.sh
 
 export EJSON_PRIVATE_KEY=$(cat "$ENV_DIR/EJSON_PRIVATE_KEY")

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -38,16 +38,16 @@ export_env_dir() {
   done
 }
 
-capture_profile_d_export_script() {
-  capture "source $TMPDIR/build/.profile.d/export_ejson_secrets.sh"
+source_profile_d_export_script() {
+  source $TMPDIR/build/.profile.d/export_ejson_secrets.sh
 }
 
 test_simple() {
   compile_with_fixture simple
   assertCapturedSuccess
 
-  capture_profile_d_export_script
-  assertCapturedSuccess
+  source_profile_d_export_script
+  export_ejson_secrets # call buildpack defined function
   assertEquals "Bar's Baz
 
 Hello" "$foo"
@@ -75,5 +75,5 @@ test_ejson_file_not_found_in_build_dir() {
 test_bad_keypair() {
   compile_with_fixture bad_keypair
   assertCapturedError
-  assertCaptured "Decryption failed"
+  assertCaptured "Decryption failed: couldn't decrypt message"
 }


### PR DESCRIPTION
And rely on the application calling export_ejson_secrets in `.profile`.

Context: https://github.com/envato/heroku-buildpack-ejson/pull/2/files#r229161880

Also, adding back the ejson error message by re-running it.