### PR TITLE
Modify PATH over hard coding full path to ejson & jq

### DIFF
--- a/.profile.d/ejson_secrets.sh
+++ b/.profile.d/ejson_secrets.sh
@@ -8,14 +8,15 @@ heading() {
 
 APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); cd ..; pwd)
 BIN_DIR="$APP_DIR/vendor/bin"
+PATH="$PATH:$BIN_DIR"
 
 decrypt_ejson_file() {
   echo $EJSON_PRIVATE_KEY | \
-    $BIN_DIR/ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1
+    ejson decrypt --key-from-stdin "$APP_DIR/$EJSON_FILE" 2>&1
 }
 
 json_to_export_lines() {
-  $BIN_DIR/jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' 2>&1 | \
+  jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")[]' 2>&1 | \
     grep -v '^export _public_key='
 }
 

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -39,7 +39,7 @@ export_env_dir() {
 }
 
 source_profile_d_export_script() {
-  source $TMPDIR/build/.profile.d/export_ejson_secrets.sh
+  source $TMPDIR/build/.profile.d/ejson_secrets.sh
 }
 
 test_simple() {


### PR DESCRIPTION
As a way to allow us to pull down this script in Heroku docker container builds and not have to symlink jq/ejson into vendor.