### PR TITLE
Add doc about setting the EJSON_AUTO_EXPORT environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Add this line to your application's `.profile` script:
 export_ejson_secrets
 ```
 
+Alternatively you can set the `EJSON_AUTO_EXPORT` environment variable.
+
+```
+heroku config:set \
+  EJSON_AUTO_EXPORT=true
+```
+
 On application start, it will use those 2 environment variables to decrypt the ejson file and export the secrets
 as environment variables.
 


### PR DESCRIPTION
Another way to auto export the ejson file to environment variables is to set the EJSON_AUTO_EXPORT variable to true.

This can be seen in use here:
https://github.com/envato/heroku-buildpack-ejson/blob/master/.profile.d/ejson_secrets.sh#L37-L39

This PR updates the docs so people are aware of this option.